### PR TITLE
Fixed issue with model loading

### DIFF
--- a/datasets/models.py
+++ b/datasets/models.py
@@ -92,6 +92,10 @@ class Dataset(models.Model):
         self.creation_time = datetime.now()
         self.status = 0
         self.save()
+        
+        # Counting weights for terms.
+        self.log("Counting weights for terms.")
+        self.reset_terms_weights()
 
     def preprocess_parse(self, params):
         self.log("Parsing documents...")
@@ -404,6 +408,12 @@ class Dataset(models.Model):
             return None
         return dataset
 
+        
+    # Returns array of terms weights. 
+    # Note. Each modality has two weights: for distance counting (spectrum) and for
+    # top terms ranking (naming). In some procedures those weights are used. To speed 
+    # up those procedures, we count all weights for terms once in reset_terms_weights
+    # and store in file. This function just read corresonding array from file.
     def get_terms_weights(self, mode):
         if not os.path.exists(os.path.join(
                 self.get_folder(), "terms_weights")):
@@ -415,7 +425,8 @@ class Dataset(models.Model):
         elif mode == "naming":
             return np.load(os.path.join(self.get_folder(),
                                         "terms_weights", "naming.npy"))
-
+    
+    # Counts weights for terms and stores them in file.
     def reset_terms_weights(self):
         folder = os.path.join(self.get_folder(), "terms_weights")
         if not os.path.exists(folder):

--- a/datasets/models.py
+++ b/datasets/models.py
@@ -92,7 +92,7 @@ class Dataset(models.Model):
         self.creation_time = datetime.now()
         self.status = 0
         self.save()
-        
+
         # Counting weights for terms.
         self.log("Counting weights for terms.")
         self.reset_terms_weights()
@@ -408,12 +408,12 @@ class Dataset(models.Model):
             return None
         return dataset
 
-        
-    # Returns array of terms weights. 
-    # Note. Each modality has two weights: for distance counting (spectrum) and for
-    # top terms ranking (naming). In some procedures those weights are used. To speed 
-    # up those procedures, we count all weights for terms once in reset_terms_weights
-    # and store in file. This function just read corresonding array from file.
+    # Returns array of terms weights.
+    # Note. Each modality has two weights: for distance counting (spectrum)
+    # and for top terms ranking (naming). In some procedures those weights are
+    # used. To speed up those procedures, we count all weights for terms once
+    # in reset_terms_weights and store in file. This function just read
+    # corresonding array from file.
     def get_terms_weights(self, mode):
         if not os.path.exists(os.path.join(
                 self.get_folder(), "terms_weights")):
@@ -425,7 +425,7 @@ class Dataset(models.Model):
         elif mode == "naming":
             return np.load(os.path.join(self.get_folder(),
                                         "terms_weights", "naming.npy"))
-    
+
     # Counts weights for terms and stores them in file.
     def reset_terms_weights(self):
         folder = os.path.join(self.get_folder(), "terms_weights")

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -239,10 +239,12 @@ def visual_dataset(request):
                 if len(freq_block) >= 100:
                     freq_block.append('...')
 
-        # Workaround: use area-step mode as bar mode with configurable bar widths
+        # Workaround: use area-step mode as bar mode with
+        # configurable bar widths.
         context['stats'] = {
             'term_freq': [
-                ['count', 0] + [x for x in count_values[1:] for _ in (0, 1)] + [count],
+                ['count', 0] +
+                [x for x in count_values[1:] for _ in (0, 1)] + [count],
                 ['freq'] + [x for x in freq_values for _ in (0, 1)]
             ],
             'term_freq_dict': term_freq_dict

--- a/models/models.py
+++ b/models/models.py
@@ -815,6 +815,10 @@ class ArtmModel(models.Model):
                 self.log(
                     ("Building topics spectrum for layer %d, "
                      "mode=%s, metric=%s...") % (layer_id, mode, metric))
+                     
+                # Default - no arranging.
+                idx = np.array(range(layer_size))
+                    
                 if mode == "alphabet":
                     # Topics are sorted by alphabet.
                     titles = [
@@ -826,10 +830,7 @@ class ArtmModel(models.Model):
                     # nearby (by solving Travelling Salesman Problem).
                     from algo.arranging.base import get_arrangement_permutation
                     idx = get_arrangement_permutation(
-                        self.topic_distances[layer_id], mode, model=self)
-                else:
-                    # No arranging.
-                    idx = np.array(range(layer_size))
+                        self.topic_distances[layer_id], mode, model=self)    
 
                 for i in range(self.get_layer_size(layer_id)):
                     topic = self.topics_index[layer_id][idx[i]]
@@ -1211,6 +1212,7 @@ class TopicInTerm(models.Model):
     topic = models.ForeignKey(Topic, null=False)
     term = models.ForeignKey(Term, null=False)
     weight = models.FloatField()
+    weight_normed = models.FloatField(default=0)
 
     def __str__(self):
         return str(self.term) + " " + str(self.topic) + \

--- a/models/models.py
+++ b/models/models.py
@@ -1205,14 +1205,13 @@ class TopTerm(models.Model):
     topic = models.ForeignKey(Topic)
     term = models.ForeignKey(Term)
     weight = models.FloatField(default=0)
-
+    weight_normed = models.FloatField(default=0)
 
 class TopicInTerm(models.Model):
     model = models.ForeignKey(ArtmModel, null=False)
     topic = models.ForeignKey(Topic, null=False)
     term = models.ForeignKey(Term, null=False)
     weight = models.FloatField()
-    weight_normed = models.FloatField(default=0)
 
     def __str__(self):
         return str(self.term) + " " + str(self.topic) + \

--- a/models/models.py
+++ b/models/models.py
@@ -801,7 +801,7 @@ class ArtmModel(models.Model):
 
         if mode == "default":
             if self.layers_count == 1:
-                mode = "hamilton"
+                mode = "index"
             else:
                 mode = "hierarchical"
 
@@ -816,16 +816,20 @@ class ArtmModel(models.Model):
                     ("Building topics spectrum for layer %d, "
                      "mode=%s, metric=%s...") % (layer_id, mode, metric))
                 if mode == "alphabet":
+                    # Topics are sorted by alphabet.
                     titles = [
                         self.topics_index[layer_id][topic_id].title
                         for topic_id in range(0, layer_size)]
                     idx = np.argsort(titles)
-                elif mode == "index":
-                    idx = np.array(range(layer_size))
-                else:
+                elif mode == "hamilton":
+                    # Topics are arranged so semantically close topics are nearby
+                    # (by solving Travelling Salesman Problem).
                     from algo.arranging.base import get_arrangement_permutation
                     idx = get_arrangement_permutation(
                         self.topic_distances[layer_id], mode, model=self)
+                else:
+                    # No arranging.
+                    idx = np.array(range(layer_size)) 
 
                 for i in range(self.get_layer_size(layer_id)):
                     topic = self.topics_index[layer_id][idx[i]]
@@ -1200,7 +1204,6 @@ class TopTerm(models.Model):
     topic = models.ForeignKey(Topic)
     term = models.ForeignKey(Term)
     weight = models.FloatField(default=0)
-    weight_normed = models.FloatField(default=0)
 
 
 class TopicInTerm(models.Model):

--- a/models/models.py
+++ b/models/models.py
@@ -822,14 +822,14 @@ class ArtmModel(models.Model):
                         for topic_id in range(0, layer_size)]
                     idx = np.argsort(titles)
                 elif mode == "hamilton":
-                    # Topics are arranged so semantically close topics are nearby
-                    # (by solving Travelling Salesman Problem).
+                    # Topics are arranged so semantically close topics are
+                    # nearby (by solving Travelling Salesman Problem).
                     from algo.arranging.base import get_arrangement_permutation
                     idx = get_arrangement_permutation(
                         self.topic_distances[layer_id], mode, model=self)
                 else:
                     # No arranging.
-                    idx = np.array(range(layer_size)) 
+                    idx = np.array(range(layer_size))
 
                 for i in range(self.get_layer_size(layer_id)):
                     topic = self.topics_index[layer_id][idx[i]]

--- a/models/views.py
+++ b/models/views.py
@@ -334,7 +334,7 @@ def visual_topic(request):
             modality = Modality.objects.get(
                 dataset=model.dataset, name=request.GET["modality"])
             top_terms = top_terms.filter(term__modality=modality)
-        top_terms = top_terms.order_by("-weight")
+        top_terms = top_terms.order_by("-weight_normed")
         context['top_terms'] = top_terms
     elif mode == 'topics':
         context['topics'] = TopicInTopic.objects.filter(parent=topic)

--- a/models/views.py
+++ b/models/views.py
@@ -334,7 +334,7 @@ def visual_topic(request):
             modality = Modality.objects.get(
                 dataset=model.dataset, name=request.GET["modality"])
             top_terms = top_terms.filter(term__modality=modality)
-        top_terms = top_terms.order_by("-weight_normed")
+        top_terms = top_terms.order_by("-weight")
         context['top_terms'] = top_terms
     elif mode == 'topics':
         context['topics'] = TopicInTopic.objects.filter(parent=topic)


### PR DESCRIPTION
* When dataset is reloaded, arrays of terms weights are counted anew. So now it's impossible to have error when model is reloading beacause of obsolete arrays in folder terms_weights.
* Changed default arranging from "hamilton" to "index" (= no arranging), so it will not try to invoke LKH algorithm by default (which causes error if it isn't installed).
* Added some comments.