### PR TITLE
Add travis-ci integration and codestyle checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - 3.6
+script:
+  - check_results=$(python manage.py lint)
+  - echo "$check_results" >&2
+  - if [[ $check_results ]]; then exit 1; fi

--- a/datasets/models.py
+++ b/datasets/models.py
@@ -5,7 +5,6 @@ from django.conf import settings
 import json
 import logging
 from datetime import datetime
-import artm
 import numpy as np
 from django.db import transaction
 from shutil import rmtree
@@ -128,6 +127,8 @@ class Dataset(models.Model):
         self.log("Filtering done.")
 
     def create_batches(self):
+        import artm
+
         self.log("Creating ARTM batches...")
         batches_folder = os.path.join(self.get_folder(), "batches")
         if os.path.exists(batches_folder):
@@ -149,6 +150,8 @@ class Dataset(models.Model):
 
     @transaction.atomic
     def gather_dictionary(self, custom_vocab=False):
+        import artm
+
         self.log("Creating ARTM dictionary...")
         dictionary = artm.Dictionary(name="dictionary")
         batches_folder = os.path.join(self.get_folder(), "batches")
@@ -290,6 +293,8 @@ class Dataset(models.Model):
         os.remove(zip_file_name)
 
     def get_batches(self):
+        import artm
+
         dataset_path = os.path.join(
             settings.DATA_DIR, "datasets", self.text_id)
         batches_folder = os.path.join(dataset_path, "batches")

--- a/models/models.py
+++ b/models/models.py
@@ -7,7 +7,6 @@ from django.conf import settings
 import json
 import numpy as np
 import pandas as pd
-import artm
 import re
 from shutil import rmtree
 from django.db import transaction
@@ -152,6 +151,8 @@ class ArtmModel(models.Model):
             self.save()
 
     def create_simple(self, iter_count, regularizers={}):
+        import artm
+
         self.log("Creating simple model...")
         layers_count = self.layers_count
         num_topics = [int(x) for x in self.topics_count.split()]
@@ -815,10 +816,10 @@ class ArtmModel(models.Model):
                 self.log(
                     ("Building topics spectrum for layer %d, "
                      "mode=%s, metric=%s...") % (layer_id, mode, metric))
-                     
+
                 # Default - no arranging.
                 idx = np.array(range(layer_size))
-                    
+
                 if mode == "alphabet":
                     # Topics are sorted by alphabet.
                     titles = [
@@ -830,7 +831,7 @@ class ArtmModel(models.Model):
                     # nearby (by solving Travelling Salesman Problem).
                     from algo.arranging.base import get_arrangement_permutation
                     idx = get_arrangement_permutation(
-                        self.topic_distances[layer_id], mode, model=self)    
+                        self.topic_distances[layer_id], mode, model=self)
 
                 for i in range(self.get_layer_size(layer_id)):
                     topic = self.topics_index[layer_id][idx[i]]
@@ -1206,6 +1207,7 @@ class TopTerm(models.Model):
     term = models.ForeignKey(Term)
     weight = models.FloatField(default=0)
     weight_normed = models.FloatField(default=0)
+
 
 class TopicInTerm(models.Model):
     model = models.ForeignKey(ArtmModel, null=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ numpy==1.12.0
 packaging==16.8
 pandas==0.19.2
 protobuf==3.2.0
-psycopg2==2.6.2
 PuLP==1.6.5
 pymorphy2==0.8
 pymorphy2-dicts==2.4.393442.3710985
@@ -19,3 +18,4 @@ python-dateutil==2.6.0
 pytz==2016.10
 six==1.10.0
 tqdm==4.11.2
+pycodestyle


### PR DESCRIPTION
There is bunch of small changes:
1. Loading of artm has made lazy (in function body). It will allow to run big number of tests without installed artm.
2. Remove psycopg2 from mandatory requirements. It is used only for PostgreSQL which is only one of possible setups and should not be mandatory. And it also blocks CI tests..
3. Add pycodestyle to requrements.txt and add .travis.yml to check code-style on pull requests.
4. Make small fixes to calm down pycodestyle.