### PR TITLE
Ability to close registration

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -75,11 +75,10 @@ def signup(request):
             request, ("Your passwords don't match."
                       "<br><a href='/accounts/signup'>Try again</a>"))
 
-    
     if registration_closed():
         return general_views.message(
             request, ("Registration is disabled on this server."))
-                          
+
     try:
         user = User.objects.create_user(username, email, password)
 
@@ -163,7 +162,8 @@ def vk_get_token(request):
 
 def vk_confirm_token(request):
     return render(request, 'accounts/vk_token_extractor.html')
-    
+
+
 def registration_closed():
     try:
         if settings.REGISTRATION_CLOSED:

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -75,6 +75,11 @@ def signup(request):
             request, ("Your passwords don't match."
                       "<br><a href='/accounts/signup'>Try again</a>"))
 
+    
+    if registration_closed():
+        return general_views.message(
+            request, ("Registration is disabled on this server."))
+                          
     try:
         user = User.objects.create_user(username, email, password)
 
@@ -158,3 +163,11 @@ def vk_get_token(request):
 
 def vk_confirm_token(request):
     return render(request, 'accounts/vk_token_extractor.html')
+    
+def registration_closed():
+    try:
+        if settings.REGISTRATION_CLOSED:
+            return True
+    except BaseException:
+        return False
+    return False

--- a/tools/views.py
+++ b/tools/views.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import os
 import zipfile
 import io
+from django.contrib.auth.decorators import login_required
 
 
 @contextmanager
@@ -26,6 +27,7 @@ def tools_list(request):
     return render(request, 'tools/tools_list.html')
 
 
+@login_required
 def vw2uci(request):
     if request.method == 'POST':
         with get_temp_folder() as folder:
@@ -59,6 +61,7 @@ class Logger:
         print(s)
 
 
+@login_required
 def uci2vw(request):
     if request.method == 'POST':
         with get_temp_folder() as folder:
@@ -94,6 +97,7 @@ def uci2vw(request):
     return render(request, 'tools/uci2vw.html')
 
 
+@login_required
 def vkloader(request):
     if request.method == 'POST':
         access_token = get_vk_access_token(request)

--- a/visartm/settings_default.py
+++ b/visartm/settings_default.py
@@ -13,6 +13,7 @@ ALLOWED_HOSTS = ["127.0.0.1"]
 
 THREADING = True
 
+REGISTRATION_CLOSED = False
 
 DEFAULT_FROM_EMAIL = 'visartm@yandex.ru'
 SERVER_EMAIL = 'visartm@yandex.ru'


### PR DESCRIPTION
Anonimous users can read-only access to server. Only registered useres are allowed to create datasets, models, etc., which loads server significantly.
This commit adds ability to forbid registration to anyone by one line in settings file. With this option server can be safely run on weak servers and we can be sure that nobody will be able to attack it by loading extreme datasets or performing calculations.
